### PR TITLE
Added some converters for ForwardedHeadersOptions

### DIFF
--- a/Pact.sln
+++ b/Pact.sln
@@ -57,6 +57,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		README.md = README.md
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Pact.Web.Isolated.Tests", "test\Pact.Web.Isolated.Tests\Pact.Web.Isolated.Tests.csproj", "{97534D22-A96F-41E5-ADCA-2474156EECF9}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -143,6 +145,10 @@ Global
 		{8AE28578-2DF3-4C0B-A230-EAB03E160821}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8AE28578-2DF3-4C0B-A230-EAB03E160821}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8AE28578-2DF3-4C0B-A230-EAB03E160821}.Release|Any CPU.Build.0 = Release|Any CPU
+		{97534D22-A96F-41E5-ADCA-2474156EECF9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{97534D22-A96F-41E5-ADCA-2474156EECF9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{97534D22-A96F-41E5-ADCA-2474156EECF9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{97534D22-A96F-41E5-ADCA-2474156EECF9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -156,6 +162,7 @@ Global
 		{361BD8F1-E213-4AB1-8B59-FBD5782D11CE} = {226EB161-A82D-42B5-851E-237887954673}
 		{C95D2509-7CC5-492A-95A7-4FA83B518F4A} = {226EB161-A82D-42B5-851E-237887954673}
 		{8F96033C-4CD3-4713-8F20-D7FAE198FC33} = {226EB161-A82D-42B5-851E-237887954673}
+		{97534D22-A96F-41E5-ADCA-2474156EECF9} = {226EB161-A82D-42B5-851E-237887954673}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {8624EA60-C90D-4B90-AFA3-F59D2B738E28}

--- a/src/Pact.Email/README.md
+++ b/src/Pact.Email/README.md
@@ -4,7 +4,19 @@ The implementation supports attachments and also the option of an override deliv
 
 DI service extensions for both variations can be found in [ServiceCollectionExtensions](./ServiceCollectionExtensions.cs).
 
-An example usage of the SendEmailAsync method follows:
+Configuring an SMTP Maildrop folder-based delivery would look as follows, in Startup.Configure:
+
+```c#
+services.AddTransient<IEmailSender, EmailSender>();
+services.AddTransient<IMaildropProvider, MaildropProvider>();
+services.Configure<EmailSettings>(Configuration.GetSection("EmailSettings"));
+```
+
+Alternatively, you could replace the IMaildropProvider implementation with an ISmtpClient one to use an SMTP service directly.
+Providing neither will just force the sender to act as a "Null" delivery service (where it'll pretend to send the email and log it, but actually do nothing - for development scenarios).
+
+An example usage of the SendEmailAsync method with an attachment, would then be:
+
 ```c#
 var attachment = new MimePart
 {
@@ -16,4 +28,5 @@ var attachment = new MimePart
   
 await _emailSender.SendEmailAsync("fred.smith@foo.bar; george.davis@foo.bar", "Hello World!", "Howdy", attachment);
 ```
+
 The API Wiki can be found [here](https://github.com/assureddt/pact/wiki/Pact-Email-Index)

--- a/src/Pact.Web/Converters/IPAddressConverter.cs
+++ b/src/Pact.Web/Converters/IPAddressConverter.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.ComponentModel;
+using System.Net;
+
+namespace Pact.Web.Converters
+{
+    /// <summary>
+    /// Provides a direct means of converting a string to an IPAddress
+    /// </summary>
+    /// <remarks>
+    /// Primary intention here is to enable us to hold IPAddresses in appsettings.json and have them deserialized without effort
+    /// </remarks>
+    public class IPAddressConverter : TypeConverter
+    {
+        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+        {
+            return sourceType == typeof(string) || base.CanConvertFrom(context, sourceType);
+        }
+
+        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+        {
+            return destinationType == typeof(string) || base.CanConvertTo(context, destinationType);
+        }
+
+        public override object ConvertFrom(ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value)
+        {
+            if (value is string s)
+            {
+                return IPAddress.Parse(s);
+            }
+            return base.ConvertFrom(context, culture, value);
+        }
+
+        public override object ConvertTo(ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value, Type destinationType)
+        {
+            return destinationType == typeof(string) ? ((IPAddress)value).ToString() : base.ConvertTo(context, culture, value, destinationType);
+        }
+
+        /// <summary>
+        /// Register the IPAddressConverter to be used for future conversions
+        /// </summary>
+        public static void Register()
+        {
+            TypeDescriptor.AddAttributes(typeof(IPAddress), new TypeConverterAttribute(typeof(IPAddressConverter)));
+        }
+    }
+}

--- a/src/Pact.Web/Converters/IPNetworkConverter.cs
+++ b/src/Pact.Web/Converters/IPNetworkConverter.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.ComponentModel;
+
+namespace Pact.Web.Converters
+{
+    /// <summary>
+    /// Provides a direct means of converting a string to an IPNetwork
+    /// </summary>
+    /// <remarks>
+    /// Primary intention here is to enable us to hold IPNetwork in appsettings.json and have them deserialized without effort
+    /// </remarks>
+    public class IPNetworkConverter : TypeConverter
+    {
+        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+        {
+            return sourceType == typeof(string) || base.CanConvertFrom(context, sourceType);
+        }
+
+        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+        {
+            return destinationType == typeof(string) || base.CanConvertTo(context, destinationType);
+        }
+
+        public override object ConvertFrom(ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value)
+        {
+            if (value is string s)
+            {
+                var ipn = System.Net.IPNetwork.Parse(s);
+                return new Microsoft.AspNetCore.HttpOverrides.IPNetwork(ipn.Network, ipn.Cidr);
+            }
+            return base.ConvertFrom(context, culture, value);
+        }
+
+        public override object ConvertTo(ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value, Type destinationType)
+        {
+            if (destinationType != typeof(string)) return base.ConvertTo(context, culture, value, destinationType);
+
+            var val = (Microsoft.AspNetCore.HttpOverrides.IPNetwork)value;
+            return $"{val.Prefix}/{val.PrefixLength}";
+        }
+
+        /// <summary>
+        /// Register the IPNetworkConverter to be used for future conversions
+        /// </summary>
+        public static void Register()
+        {
+            TypeDescriptor.AddAttributes(typeof(Microsoft.AspNetCore.HttpOverrides.IPNetwork), new TypeConverterAttribute(typeof(IPNetworkConverter)));
+        }
+    }
+}

--- a/src/Pact.Web/Options/ExtendedForwardedHeadersOptions.cs
+++ b/src/Pact.Web/Options/ExtendedForwardedHeadersOptions.cs
@@ -1,0 +1,47 @@
+﻿using System.Collections.Generic;
+using System.Net;
+using Microsoft.AspNetCore.Builder;
+
+namespace Pact.Web.Options
+{
+    /// <summary>
+    /// Extends ForwardedHeadersOptions to allow us to overwrite networks & proxies easily
+    /// </summary>
+    public class ExtendedForwardedHeadersOptions : ForwardedHeadersOptions
+    {
+        public new IList<IPAddress> KnownProxies { get; set; } = new List<IPAddress>();
+
+        public new IList<Microsoft.AspNetCore.HttpOverrides.IPNetwork> KnownNetworks { get; set; } = new List<Microsoft.AspNetCore.HttpOverrides.IPNetwork>();
+
+        /// <summary>
+        /// Apply all values to the provided ForwardedHeadersOptions object (will replace existing KnownProxies & KnownNetworks)
+        /// </summary>
+        /// <param name="fho"></param>
+        public void ApplyTo(ForwardedHeadersOptions fho)
+        {
+            fho.KnownNetworks.Clear();
+            fho.KnownProxies.Clear();
+
+            foreach (var nw in KnownNetworks)
+            {
+                fho.KnownNetworks.Add(nw);
+            }
+
+            foreach (var prox in KnownProxies)
+            {
+                fho.KnownProxies.Add(prox);
+            }
+
+            fho.AllowedHosts = AllowedHosts;
+            fho.ForwardLimit = ForwardLimit;
+            fho.ForwardedForHeaderName = ForwardedForHeaderName;
+            fho.ForwardedHeaders = ForwardedHeaders;
+            fho.ForwardedHostHeaderName = ForwardedHostHeaderName;
+            fho.ForwardedProtoHeaderName = ForwardedProtoHeaderName;
+            fho.OriginalForHeaderName = OriginalForHeaderName;
+            fho.OriginalHostHeaderName = OriginalHostHeaderName;
+            fho.OriginalProtoHeaderName = OriginalProtoHeaderName;
+            fho.RequireHeaderSymmetry = RequireHeaderSymmetry;
+        }
+    }
+}

--- a/src/Pact.Web/Pact.Web.csproj
+++ b/src/Pact.Web/Pact.Web.csproj
@@ -11,6 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="IPNetwork2" Version="2.5.226" />
     <PackageReference Include="Unidecode.NET" Version="2.1.0" />
     <PackageReference Include="NetEscapades.AspNetCore.SecurityHeaders" Version="0.13.0" />
   </ItemGroup>

--- a/test/Pact.Core.Tests/StringExtensionTests.cs
+++ b/test/Pact.Core.Tests/StringExtensionTests.cs
@@ -167,11 +167,19 @@ namespace Pact.Core.Tests
         }
 
         [Fact]
+        public void EmailAddress_OK()
+        {
+            // assert
+            "fred.smith@test.com".GetEmailAddresses().ShouldBe(new [] {"fred.smith@test.com"});
+        }
+
+        [Fact]
         public void EmailAddresses_OK()
         {
             // assert
-            "fred.smith@test.com <freddy smith, sales>, jon.smith@test.com".GetEmailAddresses().ShouldBe(new [] {"fred.smith@test.com", "jon.smith@test.com"});
+            "fred.smith@test.com <freddy smith, sales>, jon.smith@test.com".GetEmailAddresses().ShouldBe(new[] { "fred.smith@test.com", "jon.smith@test.com" });
         }
+
 
         [Fact]
         public void IsUppercaseCharacter_OK()

--- a/test/Pact.Web.Isolated.Tests/DeserializationTests.cs
+++ b/test/Pact.Web.Isolated.Tests/DeserializationTests.cs
@@ -1,0 +1,62 @@
+using System.IO;
+using System.Text;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Configuration;
+using Pact.Core.Extensions;
+using Pact.Web.Converters;
+using Pact.Web.Options;
+using Shouldly;
+using Xunit;
+
+namespace Pact.Web.Isolated.Tests
+{
+    public class DeserializationTests
+    {
+        [Fact]
+        public void Config_DeserializeForwardedHeadersOptions_OK()
+        {
+            // arrange
+            var configJson = new
+            {
+                KnownNetworks = new[] {"123.45.222.19/24"},
+                KnownProxies = new[] {"48.95.73.145"}
+            }.ToJson();
+
+            var stream = new MemoryStream(Encoding.UTF8.GetBytes(configJson));
+
+            var config = new ConfigurationBuilder()
+                .AddJsonStream(stream)
+                .Build();
+
+            // act
+            IPAddressConverter.Register();
+            IPNetworkConverter.Register();
+
+            var opts = new ForwardedHeadersOptions();
+            var ext = config.Get<ExtendedForwardedHeadersOptions>();
+            ext.ApplyTo(opts);
+
+            // assert
+            var nakedOpts = new ForwardedHeadersOptions();
+            opts.ShouldNotBeNull();
+            opts.KnownNetworks.ShouldNotBeNull();
+            opts.KnownNetworks.Count.ShouldBe(1);
+            opts.KnownNetworks[0].Prefix.ToString().ShouldBe("123.45.222.0");
+            opts.KnownNetworks[0].PrefixLength.ShouldBe(24);
+            opts.KnownProxies.ShouldNotBeNull();
+            opts.KnownProxies.Count.ShouldBe(1);
+            opts.KnownProxies[0].ToString().ShouldBe("48.95.73.145");
+
+            opts.AllowedHosts.ShouldBe(nakedOpts.AllowedHosts);
+            opts.ForwardLimit.ShouldBe(nakedOpts.ForwardLimit);
+            opts.ForwardedForHeaderName.ShouldBe(nakedOpts.ForwardedForHeaderName);
+            opts.ForwardedHeaders.ShouldBe(nakedOpts.ForwardedHeaders);
+            opts.ForwardedHostHeaderName.ShouldBe(nakedOpts.ForwardedHostHeaderName);
+            opts.ForwardedProtoHeaderName.ShouldBe(nakedOpts.ForwardedProtoHeaderName);
+            opts.OriginalForHeaderName.ShouldBe(nakedOpts.OriginalForHeaderName);
+            opts.OriginalHostHeaderName.ShouldBe(nakedOpts.OriginalHostHeaderName);
+            opts.OriginalProtoHeaderName.ShouldBe(nakedOpts.OriginalProtoHeaderName);
+            opts.RequireHeaderSymmetry.ShouldBe(nakedOpts.RequireHeaderSymmetry);
+        }
+    }
+}

--- a/test/Pact.Web.Isolated.Tests/Pact.Web.Isolated.Tests.csproj
+++ b/test/Pact.Web.Isolated.Tests/Pact.Web.Isolated.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="Moq" Version="4.16.0" />
+    <PackageReference Include="Shouldly" Version="4.0.3" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Pact.Web\Pact.Web.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/Pact.Web.Tests/ConverterTests.cs
+++ b/test/Pact.Web.Tests/ConverterTests.cs
@@ -1,0 +1,65 @@
+using System;
+using System.ComponentModel;
+using System.Net;
+using Pact.Web.Converters;
+using Shouldly;
+using Xunit;
+
+namespace Pact.Web.Tests
+{
+    public class ConverterTests
+    {
+        [Fact]
+        public void IPAddress_NoReg_Null()
+        {
+            // arrange
+            const string ip = "127.0.0.1";
+
+            // act & assert
+            Assert.Throws<NotSupportedException>(() => (IPAddress)TypeDescriptor.GetConverter(typeof(IPAddress)).ConvertFrom(ip));
+        }
+
+        [Fact]
+        public void IPAddress_Registered_AsExpected()
+        {
+            // arrange
+            const string ip = "127.0.0.1";
+
+            // act
+            // NOTE: can't use register methods here as it's app-lifetime-scoped & can't be removed
+            var ipAddress = (IPAddress)new IPAddressConverter().ConvertFrom(ip);
+
+            // assert
+            ipAddress.ShouldNotBeNull();
+            ipAddress.ToString().ShouldBe(ip);
+        }
+
+        [Fact]
+        public void IPNetwork_NoReg_Null()
+        {
+            // arrange
+            const string ipn = "123.45.222.19/24";
+
+            // act & assert
+            Assert.Throws<NotSupportedException>(() =>
+                (Microsoft.AspNetCore.HttpOverrides.IPNetwork) TypeDescriptor
+                    .GetConverter(typeof(Microsoft.AspNetCore.HttpOverrides.IPNetwork)).ConvertFrom(ipn));
+        }
+
+        [Fact]
+        public void IPNetwork_Registered_AsExpected()
+        {
+            // arrange
+            const string ipn = "123.45.222.19/24";
+
+            // act
+            // NOTE: can't use register methods here as it's app-lifetime-scoped & can't be removed
+            var ipNetwork = (Microsoft.AspNetCore.HttpOverrides.IPNetwork)new IPNetworkConverter().ConvertFrom(ipn);
+
+            // assert
+            ipNetwork.ShouldNotBeNull();
+            ipNetwork.Prefix.ToString().ShouldBe("123.45.222.0");
+            ipNetwork.PrefixLength.ShouldBe(24);
+        }
+    }
+}


### PR DESCRIPTION
A couple of the properties on the framework options class for this are get-only lists of IPAddress & IPNetworks that do not get deserialized if you pass them via appsettings.json. There are some workaround in here for this.  Also some test and documentation pieces in separate commits.