### PR TITLE
Cache API review

### DIFF
--- a/src/Pact.Cache/IDistributedCacheService.cs
+++ b/src/Pact.Cache/IDistributedCacheService.cs
@@ -16,22 +16,26 @@ namespace Pact.Cache
         void Remove(params string[] keys);
 
         /// <summary>
-        /// Get the value of a specified key and convert it to an object
+        /// Get the value of a specified key and convert it to a reference type
         /// </summary>
+        /// <remarks>Internally deserializes from JSON</remarks>
         /// <typeparam name="T"></typeparam>
         /// <param name="key"></param>
         /// <returns></returns>
         T Get<T>(string key) where T : class;
         /// <summary>
-        /// Get the string value of a specified key
+        /// Get the value type of a specified key
         /// </summary>
+        /// <remarks>Does NOT internally deserialize from JSON</remarks>
+        /// <typeparam name="T"></typeparam>
         /// <param name="key"></param>
         /// <returns></returns>
-        string Get(string key);
+        T? GetValue<T>(string key) where T: struct;
 
         /// <summary>
-        /// Convert an object to a json string and store it against the specified key
+        /// Convert a reference type to a json string and store it against the specified key
         /// </summary>
+        /// <remarks>Internally serializes to JSON</remarks>
         /// <typeparam name="T"></typeparam>
         /// <param name="key"></param>
         /// <param name="value"></param>
@@ -39,45 +43,53 @@ namespace Pact.Cache
         /// <returns></returns>
         T Set<T>(string key, T value, DistributedCacheEntryOptions options) where T : class;
         /// <summary>
-        /// Store a string value against the specified key
+        /// Store a value type against the specified key
         /// </summary>
+        /// <remarks>Does NOT internally serialize to JSON</remarks>
+        /// <typeparam name="T"></typeparam>
         /// <param name="key"></param>
         /// <param name="value"></param>
         /// <param name="options"></param>
         /// <returns></returns>
-        string Set(string key, string value, DistributedCacheEntryOptions options);
+        T? SetValue<T>(string key, T value, DistributedCacheEntryOptions options) where T: struct;
 
         /// <summary>
-        /// Convert an object to a json string and store it against the specified key
+        /// Convert a reference type to a json string and store it against the specified key
         /// </summary>
+        /// <remarks>Internally serializes to JSON</remarks>
         /// <typeparam name="T"></typeparam>
         /// <param name="key"></param>
         /// <param name="factory"></param>
         /// <returns></returns>
         T Set<T>(string key, Func<DistributedCacheEntryOptions, T> factory) where T : class;
         /// <summary>
-        /// Store a string value against the specified key
+        /// Store a value type against the specified key
         /// </summary>
+        /// <remarks>Does NOT internally serialize to JSON</remarks>
+        /// <typeparam name="T"></typeparam>
         /// <param name="key"></param>
         /// <param name="factory"></param>
         /// <returns></returns>
-        string Set(string key, Func<DistributedCacheEntryOptions, string> factory);
+        T? SetValue<T>(string key, Func<DistributedCacheEntryOptions, T> factory) where T: struct;
 
         /// <summary>
-        /// Retrieves or creates an object in json format against the specified key
+        /// Retrieves or creates a reference type in json format against the specified key
         /// </summary>
+        /// <remarks>Internally (de)serializes (from)/to JSON</remarks>
         /// <typeparam name="T"></typeparam>
         /// <param name="key"></param>
         /// <param name="factory"></param>
         /// <returns></returns>
         T GetOrCreate<T>(string key, Func<DistributedCacheEntryOptions, T> factory) where T : class;
         /// <summary>
-        /// Retrieves or creates a string value against the specified key
+        /// Retrieves or creates a value type against the specified key
         /// </summary>
+        /// <remarks>Does NOT internally (de)serialize (from)/to JSON</remarks>
+        /// <typeparam name="T"></typeparam>
         /// <param name="key"></param>
         /// <param name="factory"></param>
         /// <returns></returns>
-        string GetOrCreate(string key, Func<DistributedCacheEntryOptions, string> factory);
+        T? GetOrCreateValue<T>(string key, Func<DistributedCacheEntryOptions, T> factory) where T : struct;
 
         /// <summary>
         /// Remove specified keys
@@ -87,22 +99,26 @@ namespace Pact.Cache
         Task RemoveAsync(params string[] keys);
 
         /// <summary>
-        /// Retrieves an object from json format against the specified key
+        /// Retrieves a reference type from json format against the specified key
         /// </summary>
+        /// <remarks>Internally deserializes from JSON</remarks>
         /// <typeparam name="T"></typeparam>
         /// <param name="key"></param>
         /// <returns></returns>
         Task<T> GetAsync<T>(string key) where T : class;
         /// <summary>
-        /// Retrieves a string value against the specified key
+        /// Retrieves a value type against the specified key
         /// </summary>
+        /// <remarks>Does NOT internally deserialize from JSON</remarks>
+        /// <typeparam name="T"></typeparam>
         /// <param name="key"></param>
         /// <returns></returns>
-        Task<string> GetAsync(string key);
+        Task<T?> GetValueAsync<T>(string key) where T: struct;
 
         /// <summary>
-        /// Convert an object to a json string and store it against the specified key
+        /// Convert a reference type to a json string and store it against the specified key
         /// </summary>
+        /// <remarks>Internally serializes to JSON</remarks>
         /// <typeparam name="T"></typeparam>
         /// <param name="key"></param>
         /// <param name="value"></param>
@@ -110,44 +126,52 @@ namespace Pact.Cache
         /// <returns></returns>
         Task<T> SetAsync<T>(string key, T value, DistributedCacheEntryOptions options) where T : class;
         /// <summary>
-        /// Store a string value against the specified key
+        /// Store a value type against the specified key
         /// </summary>
+        /// <remarks>Does NOT internally serialize to JSON</remarks>
+        /// <typeparam name="T"></typeparam>
         /// <param name="key"></param>
         /// <param name="value"></param>
         /// <param name="options"></param>
         /// <returns></returns>
-        Task<string> SetAsync(string key, string value, DistributedCacheEntryOptions options);
+        Task<T?> SetValueAsync<T>(string key, T value, DistributedCacheEntryOptions options) where T: struct;
 
         /// <summary>
-        /// Convert an object to a json string and store it against the specified key
+        /// Convert a reference type to a json string and store it against the specified key
         /// </summary>
+        /// <remarks>Internally serializes to JSON</remarks>
         /// <typeparam name="T"></typeparam>
         /// <param name="key"></param>
         /// <param name="factory"></param>
         /// <returns></returns>
         Task<T> SetAsync<T>(string key, Func<DistributedCacheEntryOptions, Task<T>> factory) where T : class;
         /// <summary>
-        /// Store a string value against the specified key
+        /// Store a value type against the specified key
         /// </summary>
+        /// <remarks>Does NOT internally serialize to JSON</remarks>
+        /// <typeparam name="T"></typeparam>
         /// <param name="key"></param>
         /// <param name="factory"></param>
         /// <returns></returns>
-        Task<string> SetAsync(string key, Func<DistributedCacheEntryOptions, Task<string>> factory);
+        Task<T?> SetValueAsync<T>(string key, Func<DistributedCacheEntryOptions, Task<T>> factory) where T: struct;
 
         /// <summary>
-        /// Retrieves or creates an object in json format against the specified key
+        /// Retrieves or creates a reference type in json format against the specified key
         /// </summary>
+        /// <remarks>Internally (de)serializes (from)/to JSON</remarks>
         /// <typeparam name="T"></typeparam>
         /// <param name="key"></param>
         /// <param name="factory"></param>
         /// <returns></returns>
         Task<T> GetOrCreateAsync<T>(string key, Func<DistributedCacheEntryOptions, Task<T>> factory) where T : class;
         /// <summary>
-        /// Retrieves or creates a string value against the specified key
+        /// Retrieves or creates a value type against the specified key
         /// </summary>
+        /// <remarks>Does NOT internally (de)serialize (from)/to JSON</remarks>
+        /// <typeparam name="T"></typeparam>
         /// <param name="key"></param>
         /// <param name="factory"></param>
         /// <returns></returns>
-        Task<string> GetOrCreateAsync(string key, Func<DistributedCacheEntryOptions, Task<string>> factory);
+        Task<T?> GetOrCreateValueAsync<T>(string key, Func<DistributedCacheEntryOptions, Task<T>> factory) where T: struct;
     }
 }

--- a/src/Pact.Core/JsonSerialization.cs
+++ b/src/Pact.Core/JsonSerialization.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Pact.Core
+﻿namespace Pact.Core
 {
     public static class JsonSerialization
     {
@@ -19,7 +17,6 @@ namespace Pact.Core
         /// JsonSerialization.Serializer = JsonImplementation.Newtonsoft;
         /// </code>
         /// </example>
-        [Obsolete("We are hoping to move away from the Newtonsoft.Json serializer at some point - use with caution")]
         public static JsonImplementation Serializer { get; set; } = JsonImplementation.Microsoft;
     }
 

--- a/test/Pact.Cache.Tests/DistributedCacheServiceTests.cs
+++ b/test/Pact.Cache.Tests/DistributedCacheServiceTests.cs
@@ -23,7 +23,7 @@ namespace Pact.Cache.Tests
             var svc = new DistributedCacheService(cache.Object, new NullLogger<DistributedCacheService>());
 
             // act
-            var _ = await svc.GetAsync("test");
+            var _ = await svc.GetAsync<string>("test");
 
             // assert
             cache.Verify(m => m.GetAsync("test", It.IsAny<CancellationToken>()));
@@ -53,7 +53,7 @@ namespace Pact.Cache.Tests
             var svc = new DistributedCacheService(cache.Object, new NullLogger<DistributedCacheService>());
 
             // act
-            var _ = svc.Get("test");
+            var _ = svc.Get<string>("test");
 
             // assert
             cache.Verify(m => m.Get("test"));
@@ -82,7 +82,7 @@ namespace Pact.Cache.Tests
         public async Task GetOrCreateAsync_OK()
         {
             // arrange
-            var expectedBytes = Encoding.UTF8.GetBytes("blob");
+            var expectedBytes = Encoding.UTF8.GetBytes("\"blob\"");
             var cache = new Mock<IDistributedCache>();
             cache.Setup(m => m.GetAsync(It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync((byte[])null);
             var svc = new DistributedCacheService(cache.Object, new NullLogger<DistributedCacheService>());
@@ -118,7 +118,7 @@ namespace Pact.Cache.Tests
         public void GetOrCreate_OK()
         {
             // arrange
-            var expectedBytes = Encoding.UTF8.GetBytes("blob");
+            var expectedBytes = Encoding.UTF8.GetBytes("\"blob\"");
             var cache = new Mock<IDistributedCache>();
             cache.Setup(m => m.Get(It.IsAny<string>())).Returns((byte[])null);
             var svc = new DistributedCacheService(cache.Object, new NullLogger<DistributedCacheService>());
@@ -152,7 +152,7 @@ namespace Pact.Cache.Tests
         public async Task SetAsync_OK()
         {
             // arrange
-            var expectedBytes = Encoding.UTF8.GetBytes("blob");
+            var expectedBytes = Encoding.UTF8.GetBytes("\"blob\"");
             var cache = new Mock<IDistributedCache>();
             var svc = new DistributedCacheService(cache.Object, new NullLogger<DistributedCacheService>());
 
@@ -184,7 +184,7 @@ namespace Pact.Cache.Tests
         public void Set_OK()
         {
             // arrange
-            var expectedBytes = Encoding.UTF8.GetBytes("blob");
+            var expectedBytes = Encoding.UTF8.GetBytes("\"blob\"");
             var cache = new Mock<IDistributedCache>();
             var svc = new DistributedCacheService(cache.Object, new NullLogger<DistributedCacheService>());
 

--- a/test/Pact.Cache.Tests/IntegrationTests.cs
+++ b/test/Pact.Cache.Tests/IntegrationTests.cs
@@ -1,0 +1,368 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Pact.Core;
+using Shouldly;
+using Xunit;
+
+namespace Pact.Cache.Tests
+{
+    public class IntegrationTests
+    {
+        private readonly IOptions<MemoryDistributedCacheOptions> _opts = new OptionsWrapper<MemoryDistributedCacheOptions>(new MemoryDistributedCacheOptions());
+
+        [Fact]
+        public async Task GetStringAsync_Missing_Null()
+        {
+            // arrange
+            JsonSerialization.Serializer = JsonImplementation.Microsoft;
+            var svc = new DistributedCacheService(new MemoryDistributedCache(_opts), new NullLogger<DistributedCacheService>());
+
+            // act & assert
+            (await svc.GetAsync<string>("test")).ShouldBeNull();
+        }
+
+        [Fact]
+        public async Task GetReferenceAsync_Missing_Null()
+        {
+            // arrange
+            JsonSerialization.Serializer = JsonImplementation.Microsoft;
+            var svc = new DistributedCacheService(new MemoryDistributedCache(_opts), new NullLogger<DistributedCacheService>());
+
+            // act & assert
+            (await svc.GetAsync<MyClass>("test")).ShouldBeNull();
+        }
+
+        [Fact]
+        public async Task GetValueAsync_Missing_Null()
+        {
+            // arrange
+            JsonSerialization.Serializer = JsonImplementation.Microsoft;
+            var svc = new DistributedCacheService(new MemoryDistributedCache(_opts), new NullLogger<DistributedCacheService>());
+
+            // act & assert
+            (await svc.GetValueAsync<int>("test")).ShouldBeNull();
+        }
+        
+        [Fact]
+        public async Task GetStringAsync_Missing_NewtonSoft_Null()
+        {
+            // arrange
+            JsonSerialization.Serializer = JsonImplementation.Newtonsoft;
+            var svc = new DistributedCacheService(new MemoryDistributedCache(_opts), new NullLogger<DistributedCacheService>());
+
+            // act & assert
+            (await svc.GetAsync<string>("test")).ShouldBeNull();
+        }
+
+        [Fact]
+        public async Task GetReferenceAsync_Missing_NewtonSoft_Null()
+        {
+            // arrange
+            JsonSerialization.Serializer = JsonImplementation.Newtonsoft;
+            var svc = new DistributedCacheService(new MemoryDistributedCache(_opts), new NullLogger<DistributedCacheService>());
+
+            // act & assert
+            (await svc.GetAsync<MyClass>("test")).ShouldBeNull();
+        }
+
+        [Fact]
+        public async Task GetValueAsync_Missing_NewtonSoft_Null()
+        {
+            // arrange
+            JsonSerialization.Serializer = JsonImplementation.Newtonsoft;
+            var svc = new DistributedCacheService(new MemoryDistributedCache(_opts), new NullLogger<DistributedCacheService>());
+
+            // act & assert
+            (await svc.GetValueAsync<int>("test")).ShouldBeNull();
+        }
+
+        [Fact]
+        public async Task GetStringAsync_Found_OK()
+        {
+            // arrange
+            JsonSerialization.Serializer = JsonImplementation.Microsoft;
+            var svc = new DistributedCacheService(new MemoryDistributedCache(_opts), new NullLogger<DistributedCacheService>());
+            const string val = "testval";
+            await svc.SetAsync("test", val, new DistributedCacheEntryOptions {AbsoluteExpirationRelativeToNow = TimeSpan.FromHours(1)});
+
+            // act & assert
+            (await svc.GetAsync<string>("test")).ShouldBe(val);
+        }
+
+        [Fact]
+        public async Task GetReferenceAsync_Found_OK()
+        {
+            // arrange
+            JsonSerialization.Serializer = JsonImplementation.Microsoft;
+            var svc = new DistributedCacheService(new MemoryDistributedCache(_opts), new NullLogger<DistributedCacheService>());
+            var val = new MyClass {Id = 80, Name = "testval"};
+            await svc.SetAsync("test", val, new DistributedCacheEntryOptions {AbsoluteExpirationRelativeToNow = TimeSpan.FromHours(1)});
+
+            // act & assert
+            (await svc.GetAsync<MyClass>("test")).ShouldBeEquivalentTo(val);
+        }
+
+        [Fact]
+        public async Task GetValueAsync_Found_OK()
+        {
+            // arrange
+            JsonSerialization.Serializer = JsonImplementation.Microsoft;
+            var svc = new DistributedCacheService(new MemoryDistributedCache(_opts), new NullLogger<DistributedCacheService>());
+            const int val = 80;
+            await svc.SetValueAsync("test", val, new DistributedCacheEntryOptions {AbsoluteExpirationRelativeToNow = TimeSpan.FromHours(1)});
+
+            // act & assert
+            (await svc.GetValueAsync<int>("test")).ShouldBe(val);
+        }
+
+        [Fact]
+        public async Task GetValueAsync_WrongType_Null()
+        {
+            // arrange
+            JsonSerialization.Serializer = JsonImplementation.Microsoft;
+            var svc = new DistributedCacheService(new MemoryDistributedCache(_opts), new NullLogger<DistributedCacheService>());
+            const double val = 80.5D;
+            await svc.SetValueAsync("test", val, new DistributedCacheEntryOptions {AbsoluteExpirationRelativeToNow = TimeSpan.FromHours(1)});
+
+            // act & assert
+            (await svc.GetValueAsync<int>("test")).ShouldBeNull();
+            (await svc.GetValueAsync<double>("test")).ShouldBe(val);
+        }
+
+        [Fact]
+        public async Task GetValueAsync_Convertable_OK()
+        {
+            // arrange
+            JsonSerialization.Serializer = JsonImplementation.Microsoft;
+            var svc = new DistributedCacheService(new MemoryDistributedCache(_opts), new NullLogger<DistributedCacheService>());
+            const double val = 80.0D;
+            await svc.SetValueAsync("test", val, new DistributedCacheEntryOptions {AbsoluteExpirationRelativeToNow = TimeSpan.FromHours(1)});
+
+            // act & assert
+            (await svc.GetValueAsync<int>("test")).ShouldBe(80);
+            (await svc.GetValueAsync<double>("test")).ShouldBe(val);
+        }
+
+        
+        [Fact]
+        public async Task GetStringAsync_Found_NewtonSoft_OK()
+        {
+            // arrange
+            JsonSerialization.Serializer = JsonImplementation.Newtonsoft;
+            var svc = new DistributedCacheService(new MemoryDistributedCache(_opts), new NullLogger<DistributedCacheService>());
+            const string val = "testval";
+            await svc.SetAsync("test", val, new DistributedCacheEntryOptions {AbsoluteExpirationRelativeToNow = TimeSpan.FromHours(1)});
+
+            // act & assert
+            (await svc.GetAsync<string>("test")).ShouldBe(val);
+        }
+
+        [Fact]
+        public async Task GetReferenceAsync_Found_NewtonSoft_OK()
+        {
+            // arrange
+            JsonSerialization.Serializer = JsonImplementation.Newtonsoft;
+            var svc = new DistributedCacheService(new MemoryDistributedCache(_opts), new NullLogger<DistributedCacheService>());
+            var val = new MyClass {Id = 80, Name = "testval"};
+            await svc.SetAsync("test", val, new DistributedCacheEntryOptions {AbsoluteExpirationRelativeToNow = TimeSpan.FromHours(1)});
+
+            // act & assert
+            (await svc.GetAsync<MyClass>("test")).ShouldBeEquivalentTo(val);
+        }
+
+        [Fact]
+        public async Task GetValueAsync_Found_NewtonSoft_OK()
+        {
+            // arrange
+            JsonSerialization.Serializer = JsonImplementation.Newtonsoft;
+            var svc = new DistributedCacheService(new MemoryDistributedCache(_opts), new NullLogger<DistributedCacheService>());
+            var val = 80;
+            await svc.SetValueAsync("test", val, new DistributedCacheEntryOptions {AbsoluteExpirationRelativeToNow = TimeSpan.FromHours(1)});
+
+            // act & assert
+            (await svc.GetValueAsync<int>("test")).ShouldBe(val);
+        }
+
+        [Fact]
+        public async Task GetValueAsync_WrongType_NewtonSoft_Null()
+        {
+            // arrange
+            JsonSerialization.Serializer = JsonImplementation.Newtonsoft;
+            var svc = new DistributedCacheService(new MemoryDistributedCache(_opts), new NullLogger<DistributedCacheService>());
+            const double val = 80.5D;
+            await svc.SetValueAsync("test", val, new DistributedCacheEntryOptions {AbsoluteExpirationRelativeToNow = TimeSpan.FromHours(1)});
+
+            // act & assert
+            (await svc.GetValueAsync<int>("test")).ShouldBeNull();
+            (await svc.GetValueAsync<double>("test")).ShouldBe(val);
+        }
+
+        [Fact]
+        public async Task GetValueAsync_Convertable_NewtonSoft_OK()
+        {
+            // arrange
+            JsonSerialization.Serializer = JsonImplementation.Newtonsoft;
+            var svc = new DistributedCacheService(new MemoryDistributedCache(_opts), new NullLogger<DistributedCacheService>());
+            const double val = 80.0D;
+            await svc.SetValueAsync("test", val, new DistributedCacheEntryOptions {AbsoluteExpirationRelativeToNow = TimeSpan.FromHours(1)});
+
+            // act & assert
+            (await svc.GetValueAsync<int>("test")).ShouldBe(80);
+            (await svc.GetValueAsync<double>("test")).ShouldBe(val);
+        }
+
+        [Fact]
+        public void GetString_Missing_Null()
+        {
+            // arrange
+            JsonSerialization.Serializer = JsonImplementation.Microsoft;
+            var svc = new DistributedCacheService(new MemoryDistributedCache(_opts), new NullLogger<DistributedCacheService>());
+
+            // act & assert
+            svc.Get<string>("test").ShouldBeNull();
+        }
+
+        [Fact]
+        public void GetReference_Missing_Null()
+        {
+            // arrange
+            JsonSerialization.Serializer = JsonImplementation.Microsoft;
+            var svc = new DistributedCacheService(new MemoryDistributedCache(_opts), new NullLogger<DistributedCacheService>());
+
+            // act & assert
+            svc.Get<MyClass>("test").ShouldBeNull();
+        }
+
+        [Fact]
+        public void GetValue_Missing_Null()
+        {
+            // arrange
+            JsonSerialization.Serializer = JsonImplementation.Microsoft;
+            var svc = new DistributedCacheService(new MemoryDistributedCache(_opts), new NullLogger<DistributedCacheService>());
+
+            // act & assert
+            svc.GetValue<int>("test").ShouldBeNull();
+        }
+        
+        [Fact]
+        public void GetString_Missing_NewtonSoft_Null()
+        {
+            // arrange
+            JsonSerialization.Serializer = JsonImplementation.Newtonsoft;
+            var svc = new DistributedCacheService(new MemoryDistributedCache(_opts), new NullLogger<DistributedCacheService>());
+
+            // act & assert
+            svc.Get<string>("test").ShouldBeNull();
+        }
+
+        [Fact]
+        public void GetReference_Missing_NewtonSoft_Null()
+        {
+            // arrange
+            JsonSerialization.Serializer = JsonImplementation.Newtonsoft;
+            var svc = new DistributedCacheService(new MemoryDistributedCache(_opts), new NullLogger<DistributedCacheService>());
+
+            // act & assert
+            svc.Get<MyClass>("test").ShouldBeNull();
+        }
+
+        [Fact]
+        public void GetValue_Missing_NewtonSoft_Null()
+        {
+            // arrange
+            JsonSerialization.Serializer = JsonImplementation.Newtonsoft;
+            var svc = new DistributedCacheService(new MemoryDistributedCache(_opts), new NullLogger<DistributedCacheService>());
+
+            // act & assert
+            svc.GetValue<int>("test").ShouldBeNull();
+        }
+
+        [Fact]
+        public void GetString_Found_OK()
+        {
+            // arrange
+            JsonSerialization.Serializer = JsonImplementation.Microsoft;
+            var svc = new DistributedCacheService(new MemoryDistributedCache(_opts), new NullLogger<DistributedCacheService>());
+            const string val = "testval";
+            svc.Set("test", val, new DistributedCacheEntryOptions {AbsoluteExpirationRelativeToNow = TimeSpan.FromHours(1)});
+
+            // act & assert
+            svc.Get<string>("test").ShouldBe(val);
+        }
+
+        [Fact]
+        public void GetReference_Found_OK()
+        {
+            // arrange
+            JsonSerialization.Serializer = JsonImplementation.Microsoft;
+            var svc = new DistributedCacheService(new MemoryDistributedCache(_opts), new NullLogger<DistributedCacheService>());
+            var val = new MyClass {Id = 80, Name = "testval"};
+            svc.Set("test", val, new DistributedCacheEntryOptions {AbsoluteExpirationRelativeToNow = TimeSpan.FromHours(1)});
+
+            // act & assert
+            svc.Get<MyClass>("test").ShouldBeEquivalentTo(val);
+        }
+
+        [Fact]
+        public void GetValue_Found_OK()
+        {
+            // arrange
+            JsonSerialization.Serializer = JsonImplementation.Microsoft;
+            var svc = new DistributedCacheService(new MemoryDistributedCache(_opts), new NullLogger<DistributedCacheService>());
+            var val = 80;
+            svc.SetValue("test", val, new DistributedCacheEntryOptions {AbsoluteExpirationRelativeToNow = TimeSpan.FromHours(1)});
+
+            // act & assert
+            svc.GetValue<int>("test").ShouldBe(val);
+        }
+        
+        [Fact]
+        public void GetString_Found_NewtonSoft_OK()
+        {
+            // arrange
+            JsonSerialization.Serializer = JsonImplementation.Newtonsoft;
+            var svc = new DistributedCacheService(new MemoryDistributedCache(_opts), new NullLogger<DistributedCacheService>());
+            const string val = "testval";
+            svc.Set("test", val, new DistributedCacheEntryOptions {AbsoluteExpirationRelativeToNow = TimeSpan.FromHours(1)});
+
+            // act & assert
+            svc.Get<string>("test").ShouldBe(val);
+        }
+
+        [Fact]
+        public void GetReference_Found_NewtonSoft_OK()
+        {
+            // arrange
+            JsonSerialization.Serializer = JsonImplementation.Newtonsoft;
+            var svc = new DistributedCacheService(new MemoryDistributedCache(_opts), new NullLogger<DistributedCacheService>());
+            var val = new MyClass {Id = 80, Name = "testval"};
+            svc.Set("test", val, new DistributedCacheEntryOptions {AbsoluteExpirationRelativeToNow = TimeSpan.FromHours(1)});
+
+            // act & assert
+            svc.Get<MyClass>("test").ShouldBeEquivalentTo(val);
+        }
+
+        [Fact]
+        public void GetValue_Found_NewtonSoft_OK()
+        {
+            // arrange
+            JsonSerialization.Serializer = JsonImplementation.Newtonsoft;
+            var svc = new DistributedCacheService(new MemoryDistributedCache(_opts), new NullLogger<DistributedCacheService>());
+            var val = 80;
+            svc.SetValue("test", val, new DistributedCacheEntryOptions {AbsoluteExpirationRelativeToNow = TimeSpan.FromHours(1)});
+
+            // act & assert
+            svc.GetValue<int>("test").ShouldBe(val);
+        }
+
+        private class MyClass
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+        }
+    }
+}

--- a/test/Pact.Core.Tests/PolymorphismJsonTests.cs
+++ b/test/Pact.Core.Tests/PolymorphismJsonTests.cs
@@ -1,0 +1,77 @@
+using Pact.Core.Extensions;
+using Shouldly;
+using Xunit;
+
+namespace Pact.Core.Tests
+{
+    public class PolymorphismJsonTests
+    {
+        [Fact]
+        public void Poly_Serialize_As_Base_Microsoft_Missing_Extended_OK()
+        {
+            // arrange
+            JsonSerialization.Serializer = JsonImplementation.Microsoft;
+            var val = new MyClass {Id = 80, Name = "testval", Perc = 90.0D};
+
+            // act & assert
+            val.ToJson<MyBaseClass>().ShouldBe("{\"Id\":80,\"Name\":\"testval\"}");
+        }
+
+        [Fact]
+        public void Poly_Serialize_As_Base_Newtonsoft_Fully_Extended_OK()
+        {
+            // arrange
+            JsonSerialization.Serializer = JsonImplementation.Newtonsoft;
+            var val = new MyClass {Id = 80, Name = "testval", Perc = 90.0D};
+
+            // act & assert
+            val.ToJson<MyBaseClass>().ShouldBe("{\"Perc\":90.0,\"Id\":80,\"Name\":\"testval\"}");
+        }
+
+        [Fact]
+        public void Poly_Deserialize_As_Base_Microsoft_Missing_Extended_OK()
+        {
+            // arrange
+            JsonSerialization.Serializer = JsonImplementation.Microsoft;
+            var val = new MyClass {Id = 80, Name = "testval", Perc = 90.0D};
+            var asString = val.ToJson<MyBaseClass>();
+
+            // act
+            var result = asString.FromJson<MyClass>();
+                
+            // assert
+            result.Id.ShouldBe(val.Id);
+            result.Name.ShouldBe(val.Name);
+            // this is the difference
+            result.Perc.ShouldNotBe(val.Perc);
+        }
+
+        [Fact]
+        public void Poly_Deserialize_As_Base_Newtonsoft_Fully_Extended_OK()
+        {
+            // arrange
+            JsonSerialization.Serializer = JsonImplementation.Newtonsoft;
+            var val = new MyClass {Id = 80, Name = "testval", Perc = 90.0D};
+            var asString = val.ToJson<MyBaseClass>();
+
+            // act
+            var result = asString.FromJson<MyClass>();
+                
+            // assert
+            result.Id.ShouldBe(val.Id);
+            result.Name.ShouldBe(val.Name);
+            result.Perc.ShouldBe(val.Perc);
+        }
+
+        private class MyBaseClass
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+        }
+
+        private class MyClass : MyBaseClass
+        {
+            public double Perc { get; set; }
+        }
+    }
+}

--- a/test/Pact.Web.Isolated.Tests/DeserializationTests.cs
+++ b/test/Pact.Web.Isolated.Tests/DeserializationTests.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using System.Text;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.Extensions.Configuration;
 using Pact.Core.Extensions;
 using Pact.Web.Converters;
@@ -18,6 +19,7 @@ namespace Pact.Web.Isolated.Tests
             // arrange
             var configJson = new
             {
+                ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto,
                 KnownNetworks = new[] {"123.45.222.19/24"},
                 KnownProxies = new[] {"48.95.73.145"}
             }.ToJson();
@@ -50,7 +52,7 @@ namespace Pact.Web.Isolated.Tests
             opts.AllowedHosts.ShouldBe(nakedOpts.AllowedHosts);
             opts.ForwardLimit.ShouldBe(nakedOpts.ForwardLimit);
             opts.ForwardedForHeaderName.ShouldBe(nakedOpts.ForwardedForHeaderName);
-            opts.ForwardedHeaders.ShouldBe(nakedOpts.ForwardedHeaders);
+            opts.ForwardedHeaders.ShouldBe(ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto);
             opts.ForwardedHostHeaderName.ShouldBe(nakedOpts.ForwardedHostHeaderName);
             opts.ForwardedProtoHeaderName.ShouldBe(nakedOpts.ForwardedProtoHeaderName);
             opts.OriginalForHeaderName.ShouldBe(nakedOpts.OriginalForHeaderName);


### PR DESCRIPTION
# Improving clarity & flexibility of Cache API

Key points:

* `string` type now intended  to be handled as per other reference types (Get/SetSting variations dropped)
* Value types (`int`, `double` etc.) are now supported by a set of `Value`` suffix methods with no JSON (de)serialization involved. 

Added more detail to documentation xml.
Also added a large number of tests to assist with making the intended behaviour clear to consumers.
Hope it's not going to break anything for you!

# Adding JSON (de)serialization Polymorphism tests

Simple, but think they cover the core difference, and wanted them present since we are heavily reliant on it.
Also removing Obsolete warning because it's not going away any time soon and you mentioned they clutter the PRs.

No rush to approve this, cheers!

