### PR TITLE
Bugfix for Kendo Sort extensions

### DIFF
--- a/src/Pact.Core/Extensions/CollectionExtensions.cs
+++ b/src/Pact.Core/Extensions/CollectionExtensions.cs
@@ -272,7 +272,7 @@ namespace Pact.Core.Extensions
         /// <param name="source">list of defined object</param>
         /// <param name="sortExpression">string name of the field we want to sort by</param>
         /// <returns>Query sorted by sortExpression</returns>
-        public static IEnumerable<T> OrderBy<T>(this IEnumerable<T> source, string sortExpression) where T : class
+        public static IOrderedEnumerable<T> OrderBy<T>(this IEnumerable<T> source, string sortExpression) where T : class
         {
             var expressionParts = sortExpression.Split(' ');
             var orderByProperty = expressionParts[0];
@@ -285,6 +285,29 @@ namespace Pact.Core.Extensions
             if (expressionParts.Length > 1 && expressionParts[1] == "DESC")
                 return source.OrderByDescending(x => propertyInfo.GetValue(x, null));
             return source.OrderBy(x => propertyInfo.GetValue(x, null));
+        }
+
+        /// <summary>
+        /// Extends method which allow to sort further by additional string field name.
+        /// Allow to use a relative object definition for sorting (ex:LinkedObject.FieldsName1)
+        /// </summary>
+        /// <typeparam name="T">Current Object type for query</typeparam>
+        /// <param name="source">list of defined object</param>
+        /// <param name="sortExpression">string name of the field we want to sort by</param>
+        /// <returns>Query sorted by sortExpression</returns>
+        public static IOrderedEnumerable<T> ThenBy<T>(this IOrderedEnumerable<T> source, string sortExpression) where T : class
+        {
+            var expressionParts = sortExpression.Split(' ');
+            var orderByProperty = expressionParts[0];
+
+            var propertyInfo = typeof(T).GetProperties().FirstOrDefault(x => x.Name.ToLowerInvariant() == orderByProperty.ToLowerInvariant());
+
+            if (propertyInfo == null)
+                throw new Exception("Cant find property '" + orderByProperty + "' on type '" + typeof(T).Name + "'");
+
+            if (expressionParts.Length > 1 && expressionParts[1] == "DESC")
+                return source.ThenByDescending(x => propertyInfo.GetValue(x, null));
+            return source.ThenBy(x => propertyInfo.GetValue(x, null));
         }
 
         /// <summary>

--- a/src/Pact.Kendo/EnumerableExtensions.cs
+++ b/src/Pact.Kendo/EnumerableExtensions.cs
@@ -25,11 +25,12 @@ namespace Pact.Kendo
             source = Core.Extensions.CollectionExtensions.TextFilter(source, kendoDataRequest.TextFilter);
 
             //Sort
-            if (kendoDataRequest.Sort == null) return source;
-            if (kendoDataRequest.Sort.Count > 0)
-                source = Core.Extensions.CollectionExtensions.OrderBy(source, kendoDataRequest.Sort.First().ToString());
+            if (kendoDataRequest.Sort?.Any() != true) return source;
 
-            return source;
+            var ordered = Core.Extensions.CollectionExtensions.OrderBy(source, kendoDataRequest.Sort.First().ToString());
+            ordered = kendoDataRequest.Sort.Skip(1).Aggregate(ordered, (current, sort) => Core.Extensions.CollectionExtensions.ThenBy(current, sort.ToString()));
+
+            return ordered;
         }
 
         /// <summary>

--- a/src/Pact.Kendo/QueryableExtensions.cs
+++ b/src/Pact.Kendo/QueryableExtensions.cs
@@ -23,13 +23,10 @@ namespace Pact.Kendo
             source = EntityFrameworkCore.Extensions.QueryableExtensions.TextFilter(source, kendoDataRequest.TextFilter);
 
             //Sort
-            if (kendoDataRequest.Sort != null)
-            {
-                if (kendoDataRequest.Sort.Count > 0)
-                    source = Core.Extensions.CollectionExtensions.OrderBy(source, kendoDataRequest.Sort.First().ToString());
-                if (kendoDataRequest.Sort.Count > 1)
-                    source = Core.Extensions.CollectionExtensions.ThenBy(source, kendoDataRequest.Sort[0].ToString());
-            }
+            if (kendoDataRequest.Sort?.Any() != true) return source;
+
+            source = Core.Extensions.CollectionExtensions.OrderBy(source, kendoDataRequest.Sort.First().ToString());
+            source = kendoDataRequest.Sort.Skip(1).Aggregate(source, (current, sort) => Core.Extensions.CollectionExtensions.ThenBy(current, sort.ToString()));
 
             return source;
         }

--- a/src/Pact.TagHelpers/Pages/Account/AccessDenied.cshtml
+++ b/src/Pact.TagHelpers/Pages/Account/AccessDenied.cshtml
@@ -4,6 +4,6 @@
     ViewData["Title"] = Model.Title;
 }
 
-<h1>Model.Title</h1>
+<h1>@Model.Title</h1>
 
 <p>You do not have the necessary authorization to access this resource</p>

--- a/test/Pact.Kendo.Tests/Containers/Basic.cs
+++ b/test/Pact.Kendo.Tests/Containers/Basic.cs
@@ -4,6 +4,7 @@
     {
         public int Id { get; set; }
         public string Name { get; set; }
+        public int Order { get; set; }
         public bool SoftDelete { get; set; }
     }
 }

--- a/test/Pact.Kendo.Tests/EnumerableExtensionsTests.cs
+++ b/test/Pact.Kendo.Tests/EnumerableExtensionsTests.cs
@@ -51,6 +51,33 @@ namespace Pact.Kendo.Tests
         }
 
         [Fact]
+        public void Kendo_Multi_Sort()
+        {
+            var items = new List<Basic>();
+            items.Add(new Basic { Id = 1, Name = "Cat", Order = 0 });
+            items.Add(new Basic { Id = 2, Name = "Dog", Order = 1 });
+            items.Add(new Basic { Id = 3, Name = "Aardvark", Order = 1 });
+
+            var request = new KendoDataRequest
+            {
+                Page = 0,
+                PageSize = 5,
+                Skip = 0,
+                Take = 5,
+                Sort = new List<KendoDataRequestSort>
+                {
+                    new KendoDataRequestSort {Dir = "ASC", Field = "Order"},
+                    new KendoDataRequestSort {Dir = "ASC", Field = "Name"}
+                }
+            };
+
+            var results = items.Kendo(request);
+            Assert.True(results.First().Name == "Cat");
+            Assert.True(results.Skip(1).First().Name == "Aardvark");
+            Assert.True(results.Skip(2).First().Name == "Dog");
+        }
+
+        [Fact]
         public void KendoResult_Standard()
         {
             var items = new List<Basic>();

--- a/test/Pact.Kendo.Tests/QueryableExtensionsTests.cs
+++ b/test/Pact.Kendo.Tests/QueryableExtensionsTests.cs
@@ -65,6 +65,33 @@ namespace Pact.Kendo.Tests
         }
 
         [Fact]
+        public void Kendo_Multi_Sort()
+        {
+            var items = new List<Basic>();
+            items.Add(new Basic { Id = 1, Name = "Cat", Order = 0 });
+            items.Add(new Basic { Id = 2, Name = "Dog", Order = 1 });
+            items.Add(new Basic { Id = 3, Name = "Aardvark", Order = 1 });
+
+            var request = new KendoDataRequest
+            {
+                Page = 0,
+                PageSize = 5,
+                Skip = 0,
+                Take = 5,
+                Sort = new List<KendoDataRequestSort>
+                {
+                    new KendoDataRequestSort {Dir = "ASC", Field = "Order"},
+                    new KendoDataRequestSort {Dir = "ASC", Field = "Name"}
+                }
+            };
+
+            var results = items.AsQueryable().Kendo(request);
+            Assert.True(results.First().Name == "Cat");
+            Assert.True(results.Skip(1).First().Name == "Aardvark");
+            Assert.True(results.Skip(2).First().Name == "Dog");
+        }
+
+        [Fact]
         public async Task KendoResult_Standard()
         {
             using (var context = GetFakeContext())


### PR DESCRIPTION
@jonny64bit please do have a good check over this one - shouldn't break anything, but the .Kendo() call is a hot path.
I think the "ThenBy" logic was wonky. Added fix & tests. Also implemented ThenBy for Enumerables.
Fixed missing code context switch in AccessDenied razor page.