### PR TITLE
SMTP AUTH support in Pact.Email

### DIFF
--- a/src/Pact.Email/EmailSender.cs
+++ b/src/Pact.Email/EmailSender.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using MailKit.Net.Smtp;
-using MailKit.Security;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -56,6 +55,14 @@ namespace Pact.Email
                     await client
                         .ConnectAsync(_settings.SmtpUri, _settings.SmtpPort, _settings.SmtpSslMode)
                         .ConfigureAwait(false);
+
+                    if (!string.IsNullOrWhiteSpace(_settings.Username) &&
+                        !string.IsNullOrWhiteSpace(_settings.Password))
+                    {
+                        await client
+                            .AuthenticateAsync(_settings.Username, _settings.Password)
+                            .ConfigureAwait(false);
+                    }
                 }
 
                 foreach (var recipient in recipients.GetEmailAddresses())
@@ -131,7 +138,6 @@ namespace Pact.Email
                     }
                 }
             }
-
             finally
             {
                 if (client != null)

--- a/src/Pact.Email/EmailSettings.cs
+++ b/src/Pact.Email/EmailSettings.cs
@@ -12,5 +12,7 @@ namespace Pact.Email
         public SecureSocketOptions SmtpSslMode { get; set; } = SecureSocketOptions.Auto;
         public string OverrideToAddress { get; set; }
         public string[] OverrideWhitelist { get; set; }
+        public string Username { get; set; }
+        public string Password { get; set; }
     }
 }

--- a/src/Pact.Email/README.md
+++ b/src/Pact.Email/README.md
@@ -29,4 +29,8 @@ var attachment = new MimePart
 await _emailSender.SendEmailAsync("fred.smith@foo.bar; george.davis@foo.bar", "Hello World!", "Howdy", attachment);
 ```
 
+Now supports SMTP AUTH (for services where the mail server requires authentication e.g. M365).
+Simply provide an associated Username & Password in the EmailSettings configuration to enable that authentication step in the connection to the SMTP server.
+You will also likely need to be using the `SmtpSslMode = SecureSocketOptions.StartTls` option to support this.
+
 The API Wiki can be found [here](https://github.com/assureddt/pact/wiki/Pact-Email-Index)

--- a/test/Pact.Core.Tests/CollectionExtensionTests.cs
+++ b/test/Pact.Core.Tests/CollectionExtensionTests.cs
@@ -5,6 +5,7 @@ using Pact.Core.Extensions;
 using Pact.Core.Tests.Containers;
 using Shouldly;
 using Xunit;
+using CollectionExtensions = Pact.Core.Extensions.CollectionExtensions;
 
 namespace Pact.Core.Tests
 {
@@ -33,6 +34,98 @@ namespace Pact.Core.Tests
             items[2].Order.ShouldBe(3);
         }
 
+        [Fact]
+        public void UpdateOrder_Dec_Normalized_AllApplied()
+        {
+            // arrange
+            var items = new[]
+            {
+                new MyClass { Id = 2, Order = 1 },
+                new MyClass { Id = 1, Order = 8 },
+                new MyClass { Id = 3, Order = 1008 }
+            };
+
+            // act
+            items.UpdateOrderAndNormalize(1, CollectionExtensions.OrderShift.Decrement, x => x.Id, x => x.Order);
+
+            // assert
+            items[0].Id.ShouldBe(2);
+            items[0].Order.ShouldBe(2);
+            items[1].Id.ShouldBe(1);
+            items[1].Order.ShouldBe(1);
+            items[2].Id.ShouldBe(3);
+            items[2].Order.ShouldBe(3);
+        }
+
+        [Fact]
+        public void UpdateOrder_Dec_NotNormalized_AllApplied()
+        {
+            // arrange
+            var items = new[]
+            {
+                new MyClass { Id = 2, Order = 1 },
+                new MyClass { Id = 1, Order = 8 },
+                new MyClass { Id = 3, Order = 1008 }
+            };
+
+            // act
+            items.UpdateOrderAndNormalize(1, CollectionExtensions.OrderShift.Decrement, x => x.Id, x => x.Order, false);
+
+            // assert
+            items[0].Id.ShouldBe(2);
+            items[0].Order.ShouldBe(8);
+            items[1].Id.ShouldBe(1);
+            items[1].Order.ShouldBe(1);
+            items[2].Id.ShouldBe(3);
+            items[2].Order.ShouldBe(1008);
+        }
+
+
+        [Fact]
+        public void UpdateOrder_Inc_Normalized_AllApplied()
+        {
+            // arrange
+            var items = new[]
+            {
+                new MyClass { Id = 2, Order = 1 },
+                new MyClass { Id = 1, Order = 8 },
+                new MyClass { Id = 3, Order = 1008 }
+            };
+
+            // act
+            items.UpdateOrderAndNormalize(1, CollectionExtensions.OrderShift.Increment, x => x.Id, x => x.Order);
+
+            // assert
+            items[0].Id.ShouldBe(2);
+            items[0].Order.ShouldBe(1);
+            items[1].Id.ShouldBe(1);
+            items[1].Order.ShouldBe(3);
+            items[2].Id.ShouldBe(3);
+            items[2].Order.ShouldBe(2);
+        }
+
+        [Fact]
+        public void UpdateOrder_Inc_NotNormalized_AllApplied()
+        {
+            // arrange
+            var items = new[]
+            {
+                new MyClass { Id = 2, Order = 1 },
+                new MyClass { Id = 1, Order = 8 },
+                new MyClass { Id = 3, Order = 1008 }
+            };
+
+            // act
+            items.UpdateOrderAndNormalize(1, CollectionExtensions.OrderShift.Increment, x => x.Id, x => x.Order, false);
+
+            // assert
+            items[0].Id.ShouldBe(2);
+            items[0].Order.ShouldBe(1);
+            items[1].Id.ShouldBe(1);
+            items[1].Order.ShouldBe(1008);
+            items[2].Id.ShouldBe(3);
+            items[2].Order.ShouldBe(8);
+        }
         private class MyClass
         {
             public int Id { get; set; }

--- a/test/Pact.Email.Tests/EtherealSmtpTests.cs
+++ b/test/Pact.Email.Tests/EtherealSmtpTests.cs
@@ -1,0 +1,48 @@
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using MailKit.Net.Smtp;
+using MailKit.Security;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Pact.Email.Tests
+{
+    /// <summary>
+    /// See: https://ethereal.email/
+    /// Test creds below may no longer be valid, but no harm in trying
+    /// </summary>
+    public class EtherealSmtpTests
+    {
+        [Fact (Skip = "Ethereal Email account not intended for persistent testing")]
+        public async Task Smtp_Auth_OK()
+        {
+            // arrange
+            var services = new ServiceCollection();
+
+            var client = new SmtpClient();
+            services.AddSingleton<ISmtpClient>(client);
+            services.Configure<EmailSettings>(opts =>
+            {
+                opts.FromAddress = "aliyah37@ethereal.email";
+                opts.FromName = "Aliyah Schumm";
+                opts.SmtpPort = 587;
+                opts.SmtpUri = "smtp.ethereal.email";
+                opts.Username = "aliyah37@ethereal.email";
+                opts.Password = "JR12QjSYvREXbHP1xa";
+                opts.SmtpSslMode = SecureSocketOptions.StartTls;
+            });
+            services.AddScoped<IEmailSender, EmailSender>();
+            services.AddSingleton<ILogger<EmailSender>>(new NullLogger<EmailSender>());
+            var provider = services.BuildServiceProvider();
+
+            var sender = provider.GetService<IEmailSender>();
+
+            // act
+            await sender.SendEmailAsync("test@test.com", "test", "welcome to my test");
+        }
+    }
+}


### PR DESCRIPTION
Also add a (likely inefficient) collection reordering extension method. Closes #79