### PR TITLE
SMTP AUTH support in Pact.Email (redux)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,23 +24,6 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
            dotnet-version: '5.0.x'
-
-      - name: Add Private Nuget Feed
-        run: Out-File -FilePath "nuget.config" -InputObject "<?xml version=`"1.0`" encoding=`"utf-8`"?>
-         <configuration>
-               <packageSources>
-                    <clear />
-                    <add key=`"github`" value=`"https://nuget.pkg.github.com/assureddt/index.json`" />
-                    <add key=`"nuget`" value=`"https://api.nuget.org/v3/index.json`" />
-                </packageSources>
-                <packageSourceCredentials>
-                    <github>
-                        <add key=`"Username`" value=`"assureddt`" />
-                        <add key=`"ClearTextPassword`" value=`"${{ secrets.GITHUB_TOKEN }}`" />
-                    </github>
-                </packageSourceCredentials>
-         </configuration>"
-        shell: pwsh
         
       # Build
       - name: Restore

--- a/src/Pact.Email/EmailSender.cs
+++ b/src/Pact.Email/EmailSender.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using MailKit.Net.Smtp;
-using MailKit.Security;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -56,6 +55,14 @@ namespace Pact.Email
                     await client
                         .ConnectAsync(_settings.SmtpUri, _settings.SmtpPort, _settings.SmtpSslMode)
                         .ConfigureAwait(false);
+
+                    if (!string.IsNullOrWhiteSpace(_settings.Username) &&
+                        !string.IsNullOrWhiteSpace(_settings.Password))
+                    {
+                        await client
+                            .AuthenticateAsync(_settings.Username, _settings.Password)
+                            .ConfigureAwait(false);
+                    }
                 }
 
                 foreach (var recipient in recipients.GetEmailAddresses())
@@ -131,7 +138,6 @@ namespace Pact.Email
                     }
                 }
             }
-
             finally
             {
                 if (client != null)

--- a/src/Pact.Email/EmailSettings.cs
+++ b/src/Pact.Email/EmailSettings.cs
@@ -12,5 +12,7 @@ namespace Pact.Email
         public SecureSocketOptions SmtpSslMode { get; set; } = SecureSocketOptions.Auto;
         public string OverrideToAddress { get; set; }
         public string[] OverrideWhitelist { get; set; }
+        public string Username { get; set; }
+        public string Password { get; set; }
     }
 }

--- a/src/Pact.Email/Pact.Email.csproj
+++ b/src/Pact.Email/Pact.Email.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MailKit" Version="2.11.1" />
+    <PackageReference Include="MailKit" Version="2.13.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Pact.Email/README.md
+++ b/src/Pact.Email/README.md
@@ -29,4 +29,8 @@ var attachment = new MimePart
 await _emailSender.SendEmailAsync("fred.smith@foo.bar; george.davis@foo.bar", "Hello World!", "Howdy", attachment);
 ```
 
+Now supports SMTP AUTH (for services where the mail server requires authentication e.g. M365).
+Simply provide an associated Username & Password in the EmailSettings configuration to enable that authentication step in the connection to the SMTP server.
+You will also likely need to be using the `SmtpSslMode = SecureSocketOptions.StartTls` option to support this.
+
 The API Wiki can be found [here](https://github.com/assureddt/pact/wiki/Pact-Email-Index)

--- a/src/Pact.RabbitMQ/Pact.RabbitMQ.csproj
+++ b/src/Pact.RabbitMQ/Pact.RabbitMQ.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="5.0.*" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.*" />
-    <PackageReference Include="RabbitMQ.Client" Version="6.2.1" />
+    <PackageReference Include="RabbitMQ.Client" Version="6.2.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Pact.Web/Extensions/SecurityHeaderExtensions.cs
+++ b/src/Pact.Web/Extensions/SecurityHeaderExtensions.cs
@@ -143,7 +143,7 @@ namespace Pact.Web.Extensions
             return app.UseCspWithFeaturePolicy(false, csp =>
             {
                 csp.AddDefaultCsp(null);
-                csp.AddFrameSource().Self().FromGoogleRecaptcha();
+                csp.AddFrameSrc().Self().FromGoogleRecaptcha();
                 csp.AddImgSrc().Self().Data().FromGoogleAnalytics();
                 csp.AddConnectSrc().Self().FromGoogleAnalytics();
                 csp.AddFontSrc().Self().Data().FromGoogleFonts();
@@ -169,7 +169,7 @@ namespace Pact.Web.Extensions
             return app.UseCspWithFeaturePolicy(false, csp =>
             {
                 csp.AddDefaultCsp(null);
-                csp.AddFrameSource().None();
+                csp.AddFrameSrc().None();
                 csp.AddImgSrc().Self().Data();
                 csp.AddConnectSrc().Self();
                 csp.AddFontSrc().Self().Data();

--- a/src/Pact.Web/Pact.Web.csproj
+++ b/src/Pact.Web/Pact.Web.csproj
@@ -11,8 +11,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="IPNetwork2" Version="2.5.300" />
-    <PackageReference Include="NetEscapades.AspNetCore.SecurityHeaders" Version="0.13.0" />
+    <PackageReference Include="IPNetwork2" Version="2.5.327" />
+    <PackageReference Include="NetEscapades.AspNetCore.SecurityHeaders" Version="0.15.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'NETCOREAPP3_1' ">

--- a/test/Pact.Cache.Tests/Pact.Cache.Tests.csproj
+++ b/test/Pact.Cache.Tests/Pact.Cache.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="Shouldly" Version="4.0.3" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/test/Pact.Core.Tests/CollectionExtensionTests.cs
+++ b/test/Pact.Core.Tests/CollectionExtensionTests.cs
@@ -5,6 +5,7 @@ using Pact.Core.Extensions;
 using Pact.Core.Tests.Containers;
 using Shouldly;
 using Xunit;
+using CollectionExtensions = Pact.Core.Extensions.CollectionExtensions;
 
 namespace Pact.Core.Tests
 {
@@ -33,6 +34,98 @@ namespace Pact.Core.Tests
             items[2].Order.ShouldBe(3);
         }
 
+        [Fact]
+        public void UpdateOrder_Dec_Normalized_AllApplied()
+        {
+            // arrange
+            var items = new[]
+            {
+                new MyClass { Id = 2, Order = 1 },
+                new MyClass { Id = 1, Order = 8 },
+                new MyClass { Id = 3, Order = 1008 }
+            };
+
+            // act
+            items.UpdateOrderAndNormalize(1, CollectionExtensions.OrderShift.Decrement, x => x.Id, x => x.Order);
+
+            // assert
+            items[0].Id.ShouldBe(2);
+            items[0].Order.ShouldBe(2);
+            items[1].Id.ShouldBe(1);
+            items[1].Order.ShouldBe(1);
+            items[2].Id.ShouldBe(3);
+            items[2].Order.ShouldBe(3);
+        }
+
+        [Fact]
+        public void UpdateOrder_Dec_NotNormalized_AllApplied()
+        {
+            // arrange
+            var items = new[]
+            {
+                new MyClass { Id = 2, Order = 1 },
+                new MyClass { Id = 1, Order = 8 },
+                new MyClass { Id = 3, Order = 1008 }
+            };
+
+            // act
+            items.UpdateOrderAndNormalize(1, CollectionExtensions.OrderShift.Decrement, x => x.Id, x => x.Order, false);
+
+            // assert
+            items[0].Id.ShouldBe(2);
+            items[0].Order.ShouldBe(8);
+            items[1].Id.ShouldBe(1);
+            items[1].Order.ShouldBe(1);
+            items[2].Id.ShouldBe(3);
+            items[2].Order.ShouldBe(1008);
+        }
+
+
+        [Fact]
+        public void UpdateOrder_Inc_Normalized_AllApplied()
+        {
+            // arrange
+            var items = new[]
+            {
+                new MyClass { Id = 2, Order = 1 },
+                new MyClass { Id = 1, Order = 8 },
+                new MyClass { Id = 3, Order = 1008 }
+            };
+
+            // act
+            items.UpdateOrderAndNormalize(1, CollectionExtensions.OrderShift.Increment, x => x.Id, x => x.Order);
+
+            // assert
+            items[0].Id.ShouldBe(2);
+            items[0].Order.ShouldBe(1);
+            items[1].Id.ShouldBe(1);
+            items[1].Order.ShouldBe(3);
+            items[2].Id.ShouldBe(3);
+            items[2].Order.ShouldBe(2);
+        }
+
+        [Fact]
+        public void UpdateOrder_Inc_NotNormalized_AllApplied()
+        {
+            // arrange
+            var items = new[]
+            {
+                new MyClass { Id = 2, Order = 1 },
+                new MyClass { Id = 1, Order = 8 },
+                new MyClass { Id = 3, Order = 1008 }
+            };
+
+            // act
+            items.UpdateOrderAndNormalize(1, CollectionExtensions.OrderShift.Increment, x => x.Id, x => x.Order, false);
+
+            // assert
+            items[0].Id.ShouldBe(2);
+            items[0].Order.ShouldBe(1);
+            items[1].Id.ShouldBe(1);
+            items[1].Order.ShouldBe(1008);
+            items[2].Id.ShouldBe(3);
+            items[2].Order.ShouldBe(8);
+        }
         private class MyClass
         {
             public int Id { get; set; }

--- a/test/Pact.Core.Tests/Pact.Core.Tests.csproj
+++ b/test/Pact.Core.Tests/Pact.Core.Tests.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
     <PackageReference Include="Shouldly" Version="4.0.3" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/test/Pact.Email.Tests/EmailSenderTests.cs
+++ b/test/Pact.Email.Tests/EmailSenderTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Net.Sockets;
 using System.Text;

--- a/test/Pact.Email.Tests/EmailSenderTests.cs
+++ b/test/Pact.Email.Tests/EmailSenderTests.cs
@@ -91,6 +91,7 @@ namespace Pact.Email.Tests
 
             var client = new Mock<ISmtpClient>();
             services.AddSingleton(client.Object);
+            var junkCreds = Guid.NewGuid().ToString();
             services.Configure<EmailSettings>(opts =>
             {
                 opts.FromAddress = "origin@test.com";
@@ -98,7 +99,7 @@ namespace Pact.Email.Tests
                 opts.SmtpPort = 20;
                 opts.SmtpUri = "127.0.0.1";
                 opts.Username = "test";
-                opts.Password = "password";
+                opts.Password = junkCreds;
                 opts.SmtpSslMode = SecureSocketOptions.StartTls;
             });
             services.AddScoped<IEmailSender, EmailSender>();
@@ -112,7 +113,7 @@ namespace Pact.Email.Tests
 
             // assert
             client.Verify(m => m.ConnectAsync("127.0.0.1", 20, SecureSocketOptions.StartTls, It.IsAny<CancellationToken>()));
-            client.Verify(m => m.AuthenticateAsync("test", "password", It.IsAny<CancellationToken>()));
+            client.Verify(m => m.AuthenticateAsync("test", junkCreds, It.IsAny<CancellationToken>()));
             client.Verify(m => m.SendAsync(It.Is<MimeMessage>(x => x.HtmlBody.Contains("welcome to my test")),
                 new CancellationToken(), null));
             client.Verify(m => m.DisconnectAsync(It.IsAny<bool>(), It.IsAny<CancellationToken>()));

--- a/test/Pact.Email.Tests/EmailSenderTests.cs
+++ b/test/Pact.Email.Tests/EmailSenderTests.cs
@@ -93,14 +93,15 @@ namespace Pact.Email.Tests
             var client = new Mock<ISmtpClient>();
             services.AddSingleton(client.Object);
             var junkCreds = Guid.NewGuid().ToString();
+            var junkCreds2 = Guid.NewGuid().ToString();
             services.Configure<EmailSettings>(opts =>
             {
                 opts.FromAddress = "origin@test.com";
                 opts.FromName = "Origin";
                 opts.SmtpPort = 20;
                 opts.SmtpUri = "127.0.0.1";
-                opts.Username = "test";
-                opts.Password = junkCreds;
+                opts.Username = junkCreds;
+                opts.Password = junkCreds2;
                 opts.SmtpSslMode = SecureSocketOptions.StartTls;
             });
             services.AddScoped<IEmailSender, EmailSender>();
@@ -114,7 +115,7 @@ namespace Pact.Email.Tests
 
             // assert
             client.Verify(m => m.ConnectAsync("127.0.0.1", 20, SecureSocketOptions.StartTls, It.IsAny<CancellationToken>()));
-            client.Verify(m => m.AuthenticateAsync("test", junkCreds, It.IsAny<CancellationToken>()));
+            client.Verify(m => m.AuthenticateAsync(junkCreds, junkCreds2, It.IsAny<CancellationToken>()));
             client.Verify(m => m.SendAsync(It.Is<MimeMessage>(x => x.HtmlBody.Contains("welcome to my test")),
                 new CancellationToken(), null));
             client.Verify(m => m.DisconnectAsync(It.IsAny<bool>(), It.IsAny<CancellationToken>()));

--- a/test/Pact.Email.Tests/EtherealSmtpTests.cs
+++ b/test/Pact.Email.Tests/EtherealSmtpTests.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Threading.Tasks;
+using MailKit.Net.Smtp;
+using MailKit.Security;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Pact.Email.Tests
+{
+    public class EtherealSmtpTests
+    {
+        /// <summary>
+        /// Note: this will be skipped on CI, but will run locally. You will need to provide valid credentials in User Secrets
+        /// via: https://ethereal.email/ in order for the test to pass
+        /// </summary>
+        /// <returns></returns>
+        [SkippableFact]
+        public async Task Smtp_Auth_OK()
+        {
+            Skip.If(IsCI);
+
+            // arrange
+            var services = new ServiceCollection();
+
+            var config = new ConfigurationBuilder()
+                .AddUserSecrets<EtherealSmtpTests>()
+                .Build();
+
+            var client = new SmtpClient();
+            services.AddSingleton<ISmtpClient>(client);
+            services.Configure<EmailSettings>(opts =>
+            {
+                opts.FromAddress = config["EtherealUsername"];
+                opts.FromName = "Pact.Email.Tests";
+                opts.SmtpPort = 587;
+                opts.SmtpUri = "smtp.ethereal.email";
+                opts.Username = config["EtherealUsername"];
+                opts.Password = config["EtherealPassword"];
+                opts.SmtpSslMode = SecureSocketOptions.StartTls;
+            });
+            services.AddScoped<IEmailSender, EmailSender>();
+            services.AddSingleton<ILogger<EmailSender>>(new NullLogger<EmailSender>());
+            var provider = services.BuildServiceProvider();
+
+            var sender = provider.GetService<IEmailSender>();
+
+            // act
+            await sender.SendEmailAsync("test@test.com", "test", "welcome to my test");
+        }
+
+        private static bool IsCI => Environment.GetEnvironmentVariable("CI") != null;
+    }
+}

--- a/test/Pact.Email.Tests/Pact.Email.Tests.csproj
+++ b/test/Pact.Email.Tests/Pact.Email.Tests.csproj
@@ -4,11 +4,14 @@
     <TargetFramework>net5.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
+
+    <UserSecretsId>3eb53aed-251a-492a-b10a-c71ecd40768f</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="Shouldly" Version="4.0.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
@@ -20,6 +23,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Pact.EntityFrameworkCore.Tests/Pact.EntityFrameworkCore.Tests.csproj
+++ b/test/Pact.EntityFrameworkCore.Tests/Pact.EntityFrameworkCore.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="Shouldly" Version="4.0.3" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/test/Pact.Kendo.Tests/Pact.Kendo.Tests.csproj
+++ b/test/Pact.Kendo.Tests/Pact.Kendo.Tests.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="5.0.*" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/test/Pact.Localization.Tests/Pact.Localization.Tests.csproj
+++ b/test/Pact.Localization.Tests/Pact.Localization.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="Shouldly" Version="4.0.3" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/test/Pact.Logging.Tests/Pact.Logging.Tests.csproj
+++ b/test/Pact.Logging.Tests/Pact.Logging.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="Shouldly" Version="4.0.3" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/test/Pact.Sms.Tests/Pact.Sms.Tests.csproj
+++ b/test/Pact.Sms.Tests/Pact.Sms.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="Shouldly" Version="4.0.3" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/test/Pact.Web.Isolated.Tests/Pact.Web.Isolated.Tests.csproj
+++ b/test/Pact.Web.Isolated.Tests/Pact.Web.Isolated.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="Shouldly" Version="4.0.3" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/test/Pact.Web.Tests/Pact.Web.Tests.csproj
+++ b/test/Pact.Web.Tests/Pact.Web.Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="Shouldly" Version="4.0.3" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/test/Pact.Web.Vue.Grid.Tests/Pact.Web.Vue.Grid.Tests.csproj
+++ b/test/Pact.Web.Vue.Grid.Tests/Pact.Web.Vue.Grid.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
@@ -10,11 +10,11 @@
     <PackageReference Include="AutoMapper" Version="10.1.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.*" />
     <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="Moq.AutoMock" Version="2.3.0" />
+    <PackageReference Include="Moq.AutoMock" Version="3.0.0" />
     <PackageReference Include="Shouldly" Version="4.0.3" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="Xunit.Combinatorial" Version="1.4.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Also add a (likely inefficient) collection reordering extension method. Closes #79

Also removes a now redundant block on tests.yaml (private nuget repo setup) & replaces some soon-to-be deprecated calls on Security Headers lib. Dependency bumps. 